### PR TITLE
fix: botón duplicado en Mis Citas eliminado

### DIFF
--- a/citas/templates/citas/mis_citas.html
+++ b/citas/templates/citas/mis_citas.html
@@ -8,9 +8,6 @@
         
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h2>Mis Citas</h2>
-            <a href="{% url 'nueva_cita' %}" class="btn btn-primary">
-                <i class="bi bi-plus-lg"></i> Nueva Reserva
-            </a>
         </div>
 
         {% if citas %}


### PR DESCRIPTION
Poner botones con la misma función en la misma página es una mala práctica a la hora de diseñar interfaces web. Por eso he eliminado el botón duplicado que había en la página "Mis Citas", simplificando la experiencia del usuario.